### PR TITLE
fix v2 view definition converter

### DIFF
--- a/src/common/models/app-settings/app-settings.mocha.ts
+++ b/src/common/models/app-settings/app-settings.mocha.ts
@@ -236,6 +236,12 @@ describe("AppSettings", () => {
                 title: "Page"
               },
               {
+                formula: "$page.lookup(page_last_author)",
+                kind: "string",
+                name: "page_last_author",
+                title: "Page Author"
+              },
+              {
                 formula: "$userChars",
                 kind: "string",
                 name: "userChars",

--- a/src/common/models/dimension/dimensions.fixtures.ts
+++ b/src/common/models/dimension/dimensions.fixtures.ts
@@ -20,11 +20,11 @@ import { DimensionFixtures } from "./dimension.fixtures";
 
 export class DimensionsFixtures {
   static wikiNames(): string[] {
-    return ["time", "country", "channel", "comment", "commentLength", "commentLengthOver100", "isRobot", "namespace", "articleName", "page", "userChars"];
+    return ["time", "country", "channel", "comment", "commentLength", "commentLengthOver100", "isRobot", "namespace", "articleName", "page", "page_last_author", "userChars"];
   }
 
   static wikiTitles(): string[] {
-    return ["Time", "Country", "Channel", "Comment", "Comment Length", "Comment Length Over 100", "Is Robot", "Namespace", "Article Name", "Page", "User Chars"];
+    return ["Time", "Country", "Channel", "Comment", "Comment Length", "Comment Length Over 100", "Is Robot", "Namespace", "Article Name", "Page", "Page Author", "User Chars"];
   }
 
   static wikiJS(): DimensionOrGroupJS[] {
@@ -66,6 +66,12 @@ export class DimensionsFixtures {
         name: "page",
         title: "Page",
         formula: "$page"
+      },
+      {
+        kind: "string",
+        name: "page_last_author",
+        title: "Page Author",
+        formula: "$page.lookup(page_last_author)"
       },
       {
         kind: "string",

--- a/src/common/models/dimension/dimensions.mocha.ts
+++ b/src/common/models/dimension/dimensions.mocha.ts
@@ -45,7 +45,7 @@ describe("Dimensions", () => {
   });
 
   it("should count dimensions", () => {
-    expect(dimensions.size()).to.equal(11);
+    expect(dimensions.size()).to.equal(12);
   });
 
   it("should return the first dimension", () => {
@@ -111,18 +111,18 @@ describe("Dimensions", () => {
   it("should be immutable on append", () => {
     const newDimensions = dimensions.append(DimensionFixtures.number());
 
-    expect(dimensions.size()).to.equal(11);
+    expect(dimensions.size()).to.equal(12);
     expect(newDimensions).to.not.equal(dimensions);
     expect(newDimensions.equals(dimensions)).to.be.false;
-    expect(newDimensions.size()).to.equal(12);
+    expect(newDimensions.size()).to.equal(13);
   });
 
   it("should be immutable on prepend", () => {
     const newDimensions = dimensions.prepend(DimensionFixtures.number());
 
-    expect(dimensions.size()).to.equal(11);
+    expect(dimensions.size()).to.equal(12);
     expect(newDimensions).to.not.equal(dimensions);
     expect(newDimensions.equals(dimensions)).to.be.false;
-    expect(newDimensions.size()).to.equal(12);
+    expect(newDimensions.size()).to.equal(13);
   });
 });

--- a/src/common/view-definitions/version-2/view-definition-converter-2.fixtures.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.fixtures.ts
@@ -1,0 +1,65 @@
+import { ViewDefinition2 } from "./view-definition-2";
+
+const baseViewDefinition: ViewDefinition2 = {
+  visualization: "table",
+  timezone: "Etc/UTC",
+  filter: {
+    op: "overlap",
+    operand: {
+      op: "ref",
+      name: "time"
+    },
+    expression: {
+      op: "timeRange",
+      operand: {
+        op: "ref",
+        name: "m"
+      },
+      duration: "P1D",
+      step: -1
+    }
+  },
+  splits: [],
+  singleMeasure: "delta",
+  multiMeasureMode: true,
+  selectedMeasures: ["count"],
+  pinnedDimensions: [],
+  pinnedSort: "delta"
+};
+
+export class ViewDefinitionConverter2Fixtures {
+  static withFilterExpression(expression: any): ViewDefinition2 {
+    return {
+      ...baseViewDefinition,
+      filter: {
+        op: "overlap",
+        operand: {
+          op: "ref",
+          name: "time"
+        },
+        expression
+      }
+    };
+  }
+
+  static withFilterActions(actions: any[]): ViewDefinition2 {
+    return {
+      ...baseViewDefinition,
+      filter: {
+        op: "chain",
+        expression: {
+          op: "ref",
+          name: "time"
+        },
+        actions
+      }
+    };
+  }
+
+  static withSplits(splits: any[]): ViewDefinition2 {
+    return {
+      ...baseViewDefinition,
+      splits
+    };
+  }
+}

--- a/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
@@ -20,183 +20,90 @@ import { MANIFESTS } from "../../manifests";
 import { DataCubeFixtures } from "../../models/data-cube/data-cube.fixtures";
 import { TimeFilterPeriod } from "../../models/filter-clause/filter-clause";
 import { FilterClauseFixtures } from "../../models/filter-clause/filter-clause.fixtures";
-import { ViewDefinition2 } from "./view-definition-2";
 import { ViewDefinitionConverter2 } from "./view-definition-converter-2";
+import { ViewDefinitionConverter2Fixtures } from "./view-definition-converter-2.fixtures";
 
 describe("ViewDefinitionConverter2", () => {
 
-  const totalsWithCurrentTimeBucket: ViewDefinition2 = {
-    visualization: "totals",
-    timezone: "Etc/UTC",
-    filter: {
-      op: "overlap",
+  it("converts current time bucket expression to time period", () => {
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withFilterExpression({
+      op: "timeBucket",
       operand: {
         op: "ref",
-        name: "time"
+        name: "n"
       },
-      expression: {
-        op: "timeBucket",
-        operand: {
-          op: "ref",
-          name: "n"
-        },
-        duration: "P1D"
-      }
-    },
-    splits: [],
-    singleMeasure: "delta",
-    multiMeasureMode: true,
-    selectedMeasures: ["count"],
-    pinnedDimensions: [],
-    pinnedSort: "delta"
-  };
-
-  it("converts current time bucket expression to time period", () => {
-    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithCurrentTimeBucket, DataCubeFixtures.wiki(), MANIFESTS);
+      duration: "P1D"
+    });
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS);
     const convertedClause = essence.filter.clauses.first();
 
     const expectedClause = FilterClauseFixtures.timePeriod("time", "P1D", TimeFilterPeriod.CURRENT);
     expect(convertedClause).to.deep.equal(expectedClause);
   });
 
-  const totalsWithLatestTimeRange: ViewDefinition2 = {
-    visualization: "totals",
-    timezone: "Etc/UTC",
-    filter: {
-      op: "overlap",
+  it("converts latest time range expression to time period", () => {
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withFilterExpression({
+      op: "timeRange",
       operand: {
         op: "ref",
-        name: "time"
+        name: "m"
       },
-      expression: {
-        op: "timeRange",
-        operand: {
-          op: "ref",
-          name: "m"
-        },
-        duration: "P1D",
-        step: -3
-      }
-    },
-    splits: [],
-    singleMeasure: "delta",
-    multiMeasureMode: true,
-    selectedMeasures: ["count"],
-    pinnedDimensions: [],
-    pinnedSort: "delta"
-  };
-
-  it("converts latest time range expression to time period", () => {
-    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithLatestTimeRange, DataCubeFixtures.wiki(), MANIFESTS);
+      duration: "P1D",
+      step: -3
+    });
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS);
     const convertedClause = essence.filter.clauses.first();
 
     const expectedClause = FilterClauseFixtures.timePeriod("time", "P3D", TimeFilterPeriod.LATEST);
     expect(convertedClause).to.deep.equal(expectedClause);
   });
 
-  const totalsWithPreviousTimeRange: ViewDefinition2 = {
-    visualization: "totals",
-    timezone: "Etc/UTC",
-    filter: {
-      op: "overlap",
-      operand: {
-        op: "ref",
-        name: "time"
-      },
-      expression: {
-        op: "timeRange",
-        operand: {
-          op: "timeFloor",
-          operand: {
-            op: "ref",
-            name: "n"
-          },
-          duration: "P1W"
-        },
-        duration: "P1W",
-        step: -1
-      }
-    },
-    splits: [],
-    singleMeasure: "delta",
-    multiMeasureMode: true,
-    selectedMeasures: ["count"],
-    pinnedDimensions: [],
-    pinnedSort: "delta"
-  };
-
   it("converts previous time bucket expression to time period", () => {
-    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithPreviousTimeRange, DataCubeFixtures.wiki(), MANIFESTS);
+    const viewDefintiion = ViewDefinitionConverter2Fixtures.withFilterExpression({
+      op: "timeRange",
+      operand: {
+        op: "timeFloor",
+        operand: {
+          op: "ref",
+          name: "n"
+        },
+        duration: "P1W"
+      },
+      duration: "P1W",
+      step: -1
+    });
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(viewDefintiion, DataCubeFixtures.wiki(), MANIFESTS);
     const convertedClause = essence.filter.clauses.first();
 
     const expectedClause = FilterClauseFixtures.timePeriod("time", "P1W", TimeFilterPeriod.PREVIOUS);
     expect(convertedClause).to.deep.equal(expectedClause);
   });
 
-  const totalsWithSplits: ViewDefinition2 = {
-    visualization: "table",
-    timezone: "Etc/UTC",
-    filter: {
-      op: "chain",
-      expression: {
-        op: "ref",
-        name: "time"
-      },
-      actions: [
-        {
-          action: "in",
-          expression: {
-            op: "chain",
-            expression: {
-              op: "ref",
-              name: "n"
-            },
-            actions: [
-              {
-                action: "timeFloor",
-                duration: "P1W"
-              },
-              {
-                action: "timeRange",
-                duration: "P1W",
-                step: -1
-              }
-            ]
-          }
-        },
-        {
-          action: "and",
-          expression: {
-            op: "chain",
-            expression: {
-              op: "ref",
-              name: "page"
-            },
-            actions: [
-              {
-                action: "lookup",
-                lookup: "page_last_author"
-              },
-              {
-                action: "overlap",
-                expression: {
-                  op: "literal",
-                  value: {
-                    setType: "STRING",
-                    elements: [
-                      "TypeScript"
-                    ]
-                  },
-                  type: "SET"
-                }
-              }
-            ]
-          }
-        }
-      ]
-    },
-    splits: [
+  it("converts filter with lookup expressions", () => {
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withFilterActions([
       {
+        action: "in",
+        expression: {
+          op: "chain",
+          expression: {
+            op: "ref",
+            name: "n"
+          },
+          actions: [
+            {
+              action: "timeFloor",
+              duration: "P1W"
+            },
+            {
+              action: "timeRange",
+              duration: "P1W",
+              step: -1
+            }
+          ]
+        }
+      },
+      {
+        action: "and",
         expression: {
           op: "chain",
           expression: {
@@ -207,74 +114,95 @@ describe("ViewDefinitionConverter2", () => {
             {
               action: "lookup",
               lookup: "page_last_author"
+            },
+            {
+              action: "overlap",
+              expression: {
+                op: "literal",
+                value: {
+                  setType: "STRING",
+                  elements: [
+                    "TypeScript"
+                  ]
+                },
+                type: "SET"
+              }
             }
           ]
-        },
-        sortAction: {
-          action: "sort",
-          expression: {
-            op: "ref",
-            name: "count"
-          },
-          direction: "descending"
-        },
-        limitAction: {
-          action: "limit",
-          limit: 10
-        }
-      },
-      {
-        expression: {
-          op: "ref",
-          name: "time"
-        },
-        bucketAction: {
-          action: "timeBucket",
-          duration: "PT1H"
-        },
-        sortAction: {
-          action: "sort",
-          expression: {
-            op: "ref",
-            name: "time"
-          },
-          direction: "ascending"
         }
       }
-    ],
-    multiMeasureMode: true,
-    singleMeasure: "count",
-    selectedMeasures: [
-      "count"
-    ],
-    pinnedDimensions: [],
-    pinnedSort: "count",
-    colors: null,
-    compare: null,
-    highlight: null
-  };
-
-  it("converts filter with lookup expressions", () => {
-    const convertedFilter = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).filter;
+    ]);
+    const convertedFilter = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS).filter;
     const convertedClause = convertedFilter.clauses.get(1);
 
     const expectedClause = FilterClauseFixtures.stringIn("page_last_author", ["TypeScript"]);
     expect(convertedClause).to.deep.equal(expectedClause);
   });
 
+  const splitWithLookupAndLimit = {
+    expression: {
+      op: "chain",
+      expression: {
+        op: "ref",
+        name: "page"
+      },
+      actions: [
+        {
+          action: "lookup",
+          lookup: "page_last_author"
+        }
+      ]
+    },
+    sortAction: {
+      action: "sort",
+      expression: {
+        op: "ref",
+        name: "count"
+      },
+      direction: "descending"
+    },
+    limitAction: {
+      action: "limit",
+      limit: 10
+    }
+  };
+
   it("converts splits with lookup expressions", () => {
-    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withSplits([splitWithLookupAndLimit]);
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS).splits;
+
     expect(convertedSplits.getSplit(0).reference).to.equal("page_last_author");
   });
 
   it("converts splits with plywood < 0.14.1 limits", () => {
-    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withSplits([splitWithLookupAndLimit]);
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS).splits;
+
     expect(convertedSplits.getSplit(0).limit).to.equal(10);
   });
 
   it("converts time bucket splits", () => {
-    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
-    expect(convertedSplits.getSplit(1).bucket).to.deep.equal(Duration.fromJS("PT1H"));
+    const viewDefinition = ViewDefinitionConverter2Fixtures.withSplits([{
+      expression: {
+        op: "ref",
+        name: "time"
+      },
+      bucketAction: {
+        action: "timeBucket",
+        duration: "PT1H"
+      },
+      sortAction: {
+        action: "sort",
+        expression: {
+          op: "ref",
+          name: "time"
+        },
+        direction: "ascending"
+      }
+    }]);
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, DataCubeFixtures.wiki(), MANIFESTS).splits;
+
+    expect(convertedSplits.getSplit(0).bucket).to.deep.equal(Duration.fromJS("PT1H"));
   });
 
 });

--- a/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from "chai";
+import { Duration } from "chronoshift";
 import { MANIFESTS } from "../../manifests";
 import { DataCubeFixtures } from "../../models/data-cube/data-cube.fixtures";
 import { TimeFilterPeriod } from "../../models/filter-clause/filter-clause";
@@ -24,7 +25,7 @@ import { ViewDefinitionConverter2 } from "./view-definition-converter-2";
 
 describe("ViewDefinitionConverter2", () => {
 
-  const totalsWithTimeBucket: ViewDefinition2 = {
+  const totalsWithCurrentTimeBucket: ViewDefinition2 = {
     visualization: "totals",
     timezone: "Etc/UTC",
     filter: {
@@ -50,11 +51,227 @@ describe("ViewDefinitionConverter2", () => {
     pinnedSort: "delta"
   };
 
-  it("should convert time bucket expression to time range", () => {
-    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithTimeBucket, DataCubeFixtures.wiki(), MANIFESTS);
+  it("converts current time bucket expression to time period", () => {
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithCurrentTimeBucket, DataCubeFixtures.wiki(), MANIFESTS);
     const convertedClause = essence.filter.clauses.first();
 
-    const expectedClause = FilterClauseFixtures.timePeriod("time", "P1D", TimeFilterPeriod.LATEST);
+    const expectedClause = FilterClauseFixtures.timePeriod("time", "P1D", TimeFilterPeriod.CURRENT);
     expect(convertedClause).to.deep.equal(expectedClause);
   });
+
+  const totalsWithLatestTimeRange: ViewDefinition2 = {
+    visualization: "totals",
+    timezone: "Etc/UTC",
+    filter: {
+      op: "overlap",
+      operand: {
+        op: "ref",
+        name: "time"
+      },
+      expression: {
+        op: "timeRange",
+        operand: {
+          op: "ref",
+          name: "m"
+        },
+        duration: "P1D",
+        step: -3
+      }
+    },
+    splits: [],
+    singleMeasure: "delta",
+    multiMeasureMode: true,
+    selectedMeasures: ["count"],
+    pinnedDimensions: [],
+    pinnedSort: "delta"
+  };
+
+  it("converts latest time range expression to time period", () => {
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithLatestTimeRange, DataCubeFixtures.wiki(), MANIFESTS);
+    const convertedClause = essence.filter.clauses.first();
+
+    const expectedClause = FilterClauseFixtures.timePeriod("time", "P3D", TimeFilterPeriod.LATEST);
+    expect(convertedClause).to.deep.equal(expectedClause);
+  });
+
+  const totalsWithPreviousTimeRange: ViewDefinition2 = {
+    visualization: "totals",
+    timezone: "Etc/UTC",
+    filter: {
+      op: "overlap",
+      operand: {
+        op: "ref",
+        name: "time"
+      },
+      expression: {
+        op: "timeRange",
+        operand: {
+          op: "timeFloor",
+          operand: {
+            op: "ref",
+            name: "n"
+          },
+          duration: "P1W"
+        },
+        duration: "P1W",
+        step: -1
+      }
+    },
+    splits: [],
+    singleMeasure: "delta",
+    multiMeasureMode: true,
+    selectedMeasures: ["count"],
+    pinnedDimensions: [],
+    pinnedSort: "delta"
+  };
+
+  it("converts previous time bucket expression to time period", () => {
+    const essence = new ViewDefinitionConverter2().fromViewDefinition(totalsWithPreviousTimeRange, DataCubeFixtures.wiki(), MANIFESTS);
+    const convertedClause = essence.filter.clauses.first();
+
+    const expectedClause = FilterClauseFixtures.timePeriod("time", "P1W", TimeFilterPeriod.PREVIOUS);
+    expect(convertedClause).to.deep.equal(expectedClause);
+  });
+
+  const totalsWithSplits: ViewDefinition2 = {
+    visualization: "table",
+    timezone: "Etc/UTC",
+    filter: {
+      op: "chain",
+      expression: {
+        op: "ref",
+        name: "time"
+      },
+      actions: [
+        {
+          action: "in",
+          expression: {
+            op: "chain",
+            expression: {
+              op: "ref",
+              name: "n"
+            },
+            actions: [
+              {
+                action: "timeFloor",
+                duration: "P1W"
+              },
+              {
+                action: "timeRange",
+                duration: "P1W",
+                step: -1
+              }
+            ]
+          }
+        },
+        {
+          action: "and",
+          expression: {
+            op: "chain",
+            expression: {
+              op: "ref",
+              name: "page"
+            },
+            actions: [
+              {
+                action: "lookup",
+                lookup: "page_last_author"
+              },
+              {
+                action: "overlap",
+                expression: {
+                  op: "literal",
+                  value: {
+                    setType: "STRING",
+                    elements: [
+                      "TypeScript"
+                    ]
+                  },
+                  type: "SET"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    splits: [
+      {
+        expression: {
+          op: "chain",
+          expression: {
+            op: "ref",
+            name: "page"
+          },
+          actions: [
+            {
+              action: "lookup",
+              lookup: "page_last_author"
+            }
+          ]
+        },
+        sortAction: {
+          action: "sort",
+          expression: {
+            op: "ref",
+            name: "count"
+          },
+          direction: "descending"
+        },
+        limitAction: {
+          action: "limit",
+          limit: 10
+        }
+      },
+      {
+        expression: {
+          op: "ref",
+          name: "time"
+        },
+        bucketAction: {
+          action: "timeBucket",
+          duration: "PT1H"
+        },
+        sortAction: {
+          action: "sort",
+          expression: {
+            op: "ref",
+            name: "time"
+          },
+          direction: "ascending"
+        }
+      }
+    ],
+    multiMeasureMode: true,
+    singleMeasure: "count",
+    selectedMeasures: [
+      "count"
+    ],
+    pinnedDimensions: [],
+    pinnedSort: "count",
+    colors: null,
+    compare: null,
+    highlight: null
+  };
+
+  it("converts filter with lookup expressions", () => {
+    const convertedFilter = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).filter;
+    const convertedClause = convertedFilter.clauses.get(1);
+
+    const expectedClause = FilterClauseFixtures.stringIn("page_last_author", ["TypeScript"]);
+    expect(convertedClause).to.deep.equal(expectedClause);
+  });
+
+  it("converts splits with lookup expressions", () => {
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
+    expect(convertedSplits.length()).to.equal(2);
+    expect(convertedSplits.getSplit(0).reference).to.equal("page_last_author");
+  });
+
+  it("converts time bucket splits", () => {
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
+    expect(convertedSplits.length()).to.equal(2);
+    expect(convertedSplits.getSplit(1).bucket).to.deep.equal(Duration.fromJS("PT1H"));
+  });
+
 });

--- a/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
@@ -264,13 +264,16 @@ describe("ViewDefinitionConverter2", () => {
 
   it("converts splits with lookup expressions", () => {
     const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
-    expect(convertedSplits.length()).to.equal(2);
     expect(convertedSplits.getSplit(0).reference).to.equal("page_last_author");
+  });
+
+  it("converts splits with limits", () => {
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
+    expect(convertedSplits.getSplit(0).limit).to.equal(10);
   });
 
   it("converts time bucket splits", () => {
     const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
-    expect(convertedSplits.length()).to.equal(2);
     expect(convertedSplits.getSplit(1).bucket).to.deep.equal(Duration.fromJS("PT1H"));
   });
 

--- a/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
@@ -267,7 +267,7 @@ describe("ViewDefinitionConverter2", () => {
     expect(convertedSplits.getSplit(0).reference).to.equal("page_last_author");
   });
 
-  it("converts splits with limits", () => {
+  it("converts splits with plywood < 0.14.1 limits", () => {
     const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(totalsWithSplits, DataCubeFixtures.wiki(), MANIFESTS).splits;
     expect(convertedSplits.getSplit(0).limit).to.equal(10);
   });

--- a/src/common/view-definitions/version-2/view-definition-converter-2.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.ts
@@ -246,7 +246,7 @@ function convertSplit(split: any, dataCube: DataCube): Split {
     reference: sortAction.expression.name,
     direction: sortAction.direction
   });
-  // test fixtures and converter use value, real links generated using swiv use limit...?
+  // plywood < 0.14.1 uses limit instead of value
   const limit = limitAction && (limitAction.value || limitAction.limit);
   // test fixtures and converter use op, real links generated using swiv use action...?
   const bucket = bucketAction && ((bucketAction.action || bucketAction.op) === "timeBucket" ? Duration.fromJS(bucketAction.duration) : bucketAction.size);

--- a/src/common/view-definitions/version-2/view-definition-converter-2.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.ts
@@ -246,7 +246,8 @@ function convertSplit(split: any, dataCube: DataCube): Split {
     reference: sortAction.expression.name,
     direction: sortAction.direction
   });
-  const limit = limitAction && limitAction.value;
+  // test fixtures and converter use value, real links generated using swiv use limit...?
+  const limit = limitAction && (limitAction.value || limitAction.limit);
   // test fixtures and converter use op, real links generated using swiv use action...?
   const bucket = bucketAction && ((bucketAction.action || bucketAction.op) === "timeBucket" ? Duration.fromJS(bucketAction.duration) : bucketAction.size);
   return new Split({

--- a/src/common/view-definitions/version-2/view-definition-converter-2.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.ts
@@ -28,7 +28,6 @@ import {
   MatchExpression,
   NotExpression,
   OverlapExpression,
-  RefExpression,
   Set as PlywoodSet,
   TimeBucketExpression,
   TimeFloorExpression,
@@ -155,9 +154,10 @@ function readFixedTimeFilter(selection: LiteralExpression, dimension: Dimension)
 }
 
 function readRelativeTimeFilterClause(selection: TimeRangeExpression, dimension: Dimension): RelativeTimeFilterClause {
+  const { operand, step, duration } = selection;
   const { name: reference } = dimension;
-  if (selection.operand instanceof TimeFloorExpression) {
-    const { step, duration } = selection;
+  if (operand instanceof TimeFloorExpression) {
+    // pretty sure this is only ever used for previous
     return new RelativeTimeFilterClause({
       reference,
       duration: duration.multiply(Math.abs(step)),
@@ -166,8 +166,8 @@ function readRelativeTimeFilterClause(selection: TimeRangeExpression, dimension:
   }
   return new RelativeTimeFilterClause({
     reference,
-    period: TimeFilterPeriod.LATEST,
-    duration: selection.duration
+    period: step ? TimeFilterPeriod.LATEST : TimeFilterPeriod.CURRENT,
+    duration: step ? duration.multiply(Math.abs(step)) : duration
   });
 }
 
@@ -221,8 +221,7 @@ function expressionAction(expression: ChainableExpression): SupportedAction {
 
 function convertFilterExpression(filter: ChainableUnaryExpression, dataCube: DataCube): FilterClause {
   const { expression, exclude } = extractExclude(filter);
-  const dimensionName = (expression.operand as RefExpression).name;
-  const dimension = dataCube.getDimension(dimensionName);
+  const dimension = dataCube.getDimensionByExpression(expression.operand);
 
   if (isBooleanFilterSelection(expression.expression)) {
     return readBooleanFilterClause(expression.expression, dimension, exclude);
@@ -238,16 +237,18 @@ function convertFilterExpression(filter: ChainableUnaryExpression, dataCube: Dat
 }
 
 function convertSplit(split: any, dataCube: DataCube): Split {
-  const { sortAction, limitAction, expression, bucketAction } = split;
-  const reference = (expression as RefExpression).name;
-  const dimension = dataCube.getDimension(reference);
+  const { sortAction, limitAction, bucketAction } = split;
+  const expression = Expression.fromJS(split.expression);
+  const dimension = dataCube.getDimensionByExpression(expression);
+  const reference = dimension.name;
   const type = kindToType(dimension.kind);
   const sort = sortAction && new Sort({
     reference: sortAction.expression.name,
     direction: sortAction.direction
   });
   const limit = limitAction && limitAction.value;
-  const bucket = bucketAction && (bucketAction.op === "timeBucket" ? Duration.fromJS(bucketAction.duration) : bucketAction.size);
+  // test fixtures and converter use op, real links generated using swiv use action...?
+  const bucket = bucketAction && ((bucketAction.action || bucketAction.op) === "timeBucket" ? Duration.fromJS(bucketAction.duration) : bucketAction.size);
   return new Split({
     type,
     reference,


### PR DESCRIPTION
The current v2 view definition converter doesn't convert splits and filters using time or dimensions with lookups, fallbacks, etc. properly. The basis behind this fix is to lookup the dimension using the parsed expression (i.e. the `formula` defined in the config), rather than name.