### PR TITLE
dont apply default limit on time dimension split when autochanged

### DIFF
--- a/src/common/manifests/table/table.ts
+++ b/src/common/manifests/table/table.ts
@@ -55,7 +55,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
       }
 
       // ToDo: review this
-      if (!split.limit && (autoChanged || splitDimension.kind !== "time")) {
+      if (!split.limit && splitDimension.kind !== "time") {
         split = split.changeLimit(i ? 5 : 50);
         autoChanged = true;
       }


### PR DESCRIPTION
https://trello.com/c/5Gel61Dg/3141-pivot-time-split-working-wrong