### PR TITLE
fix adding split with shortcut

### DIFF
--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -220,7 +220,7 @@ export class DimensionListTile extends Component<DimensionListTileProps, Dimensi
           e.preventDefault();
 
           if (!essence.splits.hasSplitOn(dimension) || essence.splits.length() !== 1) {
-            clicker.changeSplit(Split.fromDimension(dimension), VisStrategy.FairGame);
+            clicker.addSplit(Split.fromDimension(dimension), VisStrategy.FairGame);
           }
 
           this.toggleSearch();


### PR DESCRIPTION
https://trello.com/c/8KORF1ln/3202-keyboard-shortcut-to-pivot-does-not-work-with-new-look