### PR TITLE
fix overflow not being displayed

### DIFF
--- a/src/client/components/filter-menu/string-filter-menu/string-filter-menu.scss
+++ b/src/client/components/filter-menu/string-filter-menu/string-filter-menu.scss
@@ -71,9 +71,7 @@
         height: 100%;
 
         .label {
-          display: inline-block;
-          vertical-align: top;
-          padding-top: 4px;
+          vertical-align: middle;
         }
       }
 


### PR DESCRIPTION
same fix is already in allegro master

[Pivot, Dimension values not displaying correctly when used in filters](https://trello.com/c/m1sS1oAP/3997-pivot-dimension-values-not-displaying-correctly-when-used-in-filters)