### PR TITLE
pst date selection in pivot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5821,9 +5821,9 @@
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lz-string": "1.4.4",
     "marked": "0.6.2",
     "moment": "2.20.1",
-    "moment-timezone": "0.5.14",
+    "moment-timezone": "0.5.26",
     "node-spawn-server": "1.0.1",
     "nopt": "4.0.1",
     "numbro": "2.1.0",


### PR DESCRIPTION
the old version of moment tz does not handle the dst change on november 2019 for the America / Los Angeles correctly. 

I couldn't reproduce the issue in tunrilo master, so just applying the fix here

[PST Date selection in Pivot](https://trello.com/c/UHjd60pc/4017-pst-date-selection-in-pivot)