### PR TITLE
Send employee region, type to mixpanel if set in jwt

### DIFF
--- a/src/client/remerge/id-token.ts
+++ b/src/client/remerge/id-token.ts
@@ -6,15 +6,22 @@ import * as Cookie from "js-cookie";
 
 const ID_TOKEN_COOKIE_NAME = "id_token";
 
-export interface IdTokenUser {
+interface IdTokenUserAdminAttributes {
+  admin: true;
+  name: string;
+  employee_type: string;
+  employee_region: string;
+}
+
+interface IdTokenUserClientAttributes {
+  admin: false;
+}
+
+type IdTokenUser = {
   id: number;
   email: string;
-  name: string;
   organizations: number[];
-  admin: boolean;
-  employee_type?: string;
-  employee_region?: string;
-}
+} & (IdTokenUserAdminAttributes | IdTokenUserClientAttributes);
 
 export interface IdToken {
   exp: number;

--- a/src/client/remerge/id-token.ts
+++ b/src/client/remerge/id-token.ts
@@ -12,6 +12,8 @@ export interface IdTokenUser {
   name: string;
   organizations: number[];
   admin: boolean;
+  employee_type?: string;
+  employee_region?: string;
 }
 
 export interface IdToken {

--- a/src/client/remerge/tracking.ts
+++ b/src/client/remerge/tracking.ts
@@ -124,7 +124,7 @@ interface SplitDetail {
 function trackableSplits(essence: Essence): SplitDetail[] {
   const { dataCube } = essence;
 
-  return Array.from (essence.splits.splits.map(split => {
+  return Array.from(essence.splits.splits.map(split => {
     const dimension = dataCube.getDimension(split.reference);
 
     const splitDetail: SplitDetail = { dimension: dimension.title };
@@ -187,22 +187,34 @@ function sendTrackingEvent({
     const nonTimeFilters = filters.filter(filter => !isTimeFilter(filter));
 
     const timeShift = essence.timeShift;
+    const idToken = parseIdToken();
 
-    track(eventType, {
-      time: viewStartAt,
-      $duration: viewStartAt && secondsSince(viewStartAt),
-      reportDuration: timeFilter,
-      timeShift: timeShift.value && timeShift.getDescription(),
-      filters: nonTimeFilters.map(filter => filter.dimension),
-      filterDetails: nonTimeFilters,
-      splits: splits.map(split => split.dimension),
-      splitsDetails: splits,
-      kpis,
-      visualization,
-      timeToRender,
-      timezone: essence.timezone.toString(),
-      errorMessage
-    }, onPageUnload);
+    track(
+      eventType,
+      {
+        time: viewStartAt,
+        $duration: viewStartAt && secondsSince(viewStartAt),
+        reportDuration: timeFilter,
+        timeShift: timeShift.value && timeShift.getDescription(),
+        filters: nonTimeFilters.map((filter) => filter.dimension),
+        filterDetails: nonTimeFilters,
+        splits: splits.map((split) => split.dimension),
+        splitsDetails: splits,
+        kpis,
+        visualization,
+        timeToRender,
+        timezone: essence.timezone.toString(),
+        errorMessage,
+        ...(idToken && idToken.user.admin
+          ? {
+            name: idToken.user.name,
+            employee_type: idToken.user.employee_type || "unknown",
+            employee_region: idToken.user.employee_region || "unknown",
+          }
+          : { name: null, employee_type: null, employee_region: null }),
+      },
+      onPageUnload
+    );
 
   } catch (error) {
     reportError(error);

--- a/src/client/remerge/tracking.ts
+++ b/src/client/remerge/tracking.ts
@@ -196,9 +196,9 @@ function sendTrackingEvent({
         $duration: viewStartAt && secondsSince(viewStartAt),
         reportDuration: timeFilter,
         timeShift: timeShift.value && timeShift.getDescription(),
-        filters: nonTimeFilters.map((filter) => filter.dimension),
+        filters: nonTimeFilters.map(filter => filter.dimension),
         filterDetails: nonTimeFilters,
-        splits: splits.map((split) => split.dimension),
+        splits: splits.map(split => split.dimension),
         splitsDetails: splits,
         kpis,
         visualization,
@@ -209,9 +209,9 @@ function sendTrackingEvent({
           ? {
             name: idToken.user.name,
             employee_type: idToken.user.employee_type || "unknown",
-            employee_region: idToken.user.employee_region || "unknown",
+            employee_region: idToken.user.employee_region || "unknown"
           }
-          : { name: null, employee_type: null, employee_region: null }),
+          : { name: null, employee_type: null, employee_region: null })
       },
       onPageUnload
     );


### PR DESCRIPTION
Admin users have employee_region and employee_type set in the jwt
token (added by this PR https://github.com/remerge/api/pull/2253).
We now pass these values along to mixpanel to allow filtering
of users based on these properties

[Add User Name, Employee Type, Employee Region to Pivot tracking](https://trello.com/c/sgWhLOjZ/4544-add-user-name-employee-type-employee-region-to-pivot-tracking)